### PR TITLE
feat: Implement global error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +177,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",
+ "thiserror",
  "toml",
 ]
 

--- a/crates/wackdb_common/Cargo.toml
+++ b/crates/wackdb_common/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.1.2"
 anyhow = "1.0.102"
+thiserror = "2.0.18"

--- a/crates/wackdb_common/src/errors.rs
+++ b/crates/wackdb_common/src/errors.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+use std::io;
+use thiserror::Error;
+
+#[derive(Error, Debug, Serialize, Deserialize)]
+pub enum DatabaseError {
+    #[error("I/O error: {0}")]
+    Io(String),
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    #[error("Page corrupted: ID {page_id}, checksum mismatch")]
+    PageCorrupted { page_id: u32 },
+
+    #[error("Storage error: {0}")]
+    Storage(String),
+}
+
+impl From<io::Error> for DatabaseError {
+    fn from(err: io::Error) -> Self {
+        DatabaseError::Io(err.to_string())
+    }
+}

--- a/crates/wackdb_common/src/lib.rs
+++ b/crates/wackdb_common/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod constants;
+pub mod errors;
 pub mod types;
 
 pub use config::Config;
@@ -9,3 +10,7 @@ pub use constants::{
 pub use types::{
     BufferTag, FrameId, LocalPageId, Lsn, PageId, Rid, SegmentIndex, SlotId, TransactionId,
 };
+
+pub use errors::DatabaseError;
+
+pub type Result<T> = std::result::Result<T, DatabaseError>;


### PR DESCRIPTION
Closes #7 
This PR adds a global error system in wackdb_common to handle and propagate failures across all layers

Tasks:
- [x] Implement `DatabaseError` enum in `errors.rs`
- [x] Add variants for: `Io`, `Serialization`, `PageCorrupted`, and `Storage`
- [x] Add Serialize/Deserialize for logging and recovery
- [x] Implement `From<std::io::Error>` for automatic conversion
- [x] Define `pub type Result<T>` = `std::result::Result<T, DatabaseError>` in `lib.rs`