### PR TITLE
feat: add atomic writing and configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,11 +358,15 @@ dependencies = [
  "serde",
  "thiserror",
  "toml",
+ "zerocopy",
 ]
 
 [[package]]
 name = "wackdb_page"
 version = "0.1.0"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "wackdb_storage"
@@ -540,6 +544,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/wackdb_cli/src/main.rs
+++ b/crates/wackdb_cli/src/main.rs
@@ -15,9 +15,7 @@ fn main() -> Result<()> {
 
     println!("Configuration loaded:");
     println!("  PAGE_SIZE: {}", config.page_size);
-    println!("  BUFFER_POOL_SIZE: {}", config.buffer_pool_size);
-    println!("  SEGMENT_SIZE: {}", config.segment_size);
-    println!("  LRU_CAPACITY: {}", config.lru_capacity);
+    println!("  DATA_DIR: {}", config.data_dir);
 
     Ok(())
 }

--- a/crates/wackdb_common/Cargo.toml
+++ b/crates/wackdb_common/Cargo.toml
@@ -8,3 +8,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 toml = "1.1.2"
 anyhow = "1.0.102"
 thiserror = "2.0.18"
+zerocopy = { version = "0.8.48", features = ["derive"] }

--- a/crates/wackdb_common/src/config.rs
+++ b/crates/wackdb_common/src/config.rs
@@ -1,37 +1,48 @@
 use anyhow::{Result, bail};
 use serde::{Deserialize, Serialize};
-use std::fs;
-use std::path::Path;
+use std::{fs, path::Path};
+
+const DEFAULT_DATA_DIR: &str = "data";
+const DEFAULT_PAGE_SIZE: usize = 8 * 1024;
+
+const MIN_DISK_SECTOR_SIZE: usize = 512;
+const STANDARD_MEMORY_PAGE_SIZE: usize = 4 * 1024;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
     pub data_dir: String,
     pub page_size: usize,
-    pub buffer_pool_size: usize,
-    pub segment_size: u64,
-    pub lru_capacity: usize,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            data_dir: "data".to_string(),
-            page_size: 8192,
-            buffer_pool_size: 1024,
-            segment_size: 1024 * 1024 * 1024,
-            lru_capacity: 1024,
+            data_dir: DEFAULT_DATA_DIR.to_string(),
+            page_size: DEFAULT_PAGE_SIZE,
         }
     }
 }
 
 impl Config {
     pub fn validate(&self) -> Result<()> {
+        self.validate_page_size()?;
+        Ok(())
+    }
+
+    fn validate_page_size(&self) -> Result<()> {
         if self.page_size == 0 {
-            bail!("PAGE_SIZE must be greater than 0");
+            bail!("page_size must be greater than 0");
         }
 
-        if !self.page_size.is_multiple_of(512) && self.page_size.is_multiple_of(4096) {
-            bail!("PAGE_SIZE must be a multiple of 512 or 4096");
+        let is_valid_size = self.page_size.is_multiple_of(MIN_DISK_SECTOR_SIZE)
+            || self.page_size.is_multiple_of(STANDARD_MEMORY_PAGE_SIZE);
+
+        if !is_valid_size {
+            bail!(
+                "page_size must be a multiple of {} or {}",
+                MIN_DISK_SECTOR_SIZE,
+                STANDARD_MEMORY_PAGE_SIZE
+            );
         }
 
         Ok(())
@@ -39,7 +50,7 @@ impl Config {
 
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let content = fs::read_to_string(path)?;
-        let config: Config = toml::from_str(&content)?;
+        let config: Self = toml::from_str(&content)?;
         config.validate()?;
         Ok(config)
     }

--- a/crates/wackdb_common/src/constants.rs
+++ b/crates/wackdb_common/src/constants.rs
@@ -2,7 +2,7 @@ use crate::types::{FrameId, Lsn, PageId, SlotId, TransactionId};
 
 pub const PAGE_SIZE: usize = 8192;
 
-pub const INVALID_PAGE_ID: PageId = PageId(u32::MAX);
+pub const INVALID_PAGE_ID: PageId = PageId(u64::MAX);
 
 pub const INVALID_FRAME_ID: FrameId = FrameId(u32::MAX);
 

--- a/crates/wackdb_common/src/types.rs
+++ b/crates/wackdb_common/src/types.rs
@@ -1,14 +1,31 @@
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, FromBytes, IntoBytes, Immutable,
+)]
 #[repr(transparent)]
-pub struct PageId(pub u32);
+pub struct PageId(pub u64);
 
 impl PageId {
-    pub fn to_le_bytes(self) -> [u8; 4] {
+    pub fn new(table_id: u32, page_idx: u32) -> Self {
+        let id = ((table_id as u64) << 32) | (page_idx as u64);
+        Self(id)
+    }
+
+    pub fn table_id(self) -> u32 {
+        (self.0 >> 32) as u32
+    }
+
+    pub fn page_idx(self) -> u32 {
+        (self.0 & 0xFFFF_FFFF) as u32
+    }
+
+    pub fn to_le_bytes(self) -> [u8; 8] {
         self.0.to_le_bytes()
     }
 
-    pub fn from_le_bytes(bytes: [u8; 4]) -> Self {
-        Self(u32::from_le_bytes(bytes))
+    pub fn from_le_bytes(bytes: [u8; 8]) -> Self {
+        Self(u64::from_le_bytes(bytes))
     }
 }
 
@@ -110,13 +127,13 @@ impl LocalPageId {
     }
 }
 
-impl From<u32> for PageId {
-    fn from(id: u32) -> Self {
+impl From<u64> for PageId {
+    fn from(id: u64) -> Self {
         Self(id)
     }
 }
 
-impl From<PageId> for u32 {
+impl From<PageId> for u64 {
     fn from(id: PageId) -> Self {
         id.0
     }

--- a/crates/wackdb_page/Cargo.toml
+++ b/crates/wackdb_page/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+zerocopy = { version = "0.8.48", features = ["derive"] }

--- a/crates/wackdb_storage/src/disk_manager.rs
+++ b/crates/wackdb_storage/src/disk_manager.rs
@@ -8,16 +8,22 @@ use wackdb_common::constants::PAGE_SIZE;
 use wackdb_common::errors::DatabaseError;
 use wackdb_common::types::PageId;
 
+/// DiskManager manages the physical persistence of fixed-size 8KB pages.
+///
+/// It provides basic I/O operations and guarantees atomicity during page updates
+/// by employing a temporary file swap (Shadow Paging) strategy combined with
+/// explicit filesystem synchronization.
 pub struct DiskManager {
     data_dir: PathBuf,
     opened_files: HashMap<u32, File>,
 }
 
 impl DiskManager {
+    /// Initializes the DiskManager and ensures the data directory exists.
     pub fn new(config: &Config) -> Result<Self, DatabaseError> {
         let data_dir = PathBuf::from(&config.data_dir);
         if !data_dir.exists() {
-            fs::create_dir_all(&data_dir).map_err(|e| DatabaseError::Io(e.to_string()))?;
+            fs::create_dir_all(&data_dir)?;
         }
 
         Ok(Self {
@@ -26,12 +32,31 @@ impl DiskManager {
         })
     }
 
-    pub fn read_page(
-        &mut self,
-        table_id: u32,
-        page_id: PageId,
-    ) -> Result<[u8; PAGE_SIZE], DatabaseError> {
-        let offset = page_id.0 as u64 * PAGE_SIZE as u64;
+    /// Creates a new database file for the specified table ID.
+    pub fn create_file(&mut self, table_id: u32) -> Result<(), DatabaseError> {
+        let path = self.resolve_physical_location_path(table_id);
+        if path.exists() {
+            return Err(DatabaseError::Storage(format!(
+                "File for table {} already exists",
+                table_id
+            )));
+        }
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&path)?;
+
+        file.sync_all()?;
+        self.opened_files.insert(table_id, file);
+        Ok(())
+    }
+
+    /// Reads an 8KB page from disk.
+    pub fn read_page(&mut self, page_id: PageId) -> Result<[u8; PAGE_SIZE], DatabaseError> {
+        let table_id = page_id.table_id();
+        let offset = page_id.page_idx() as u64 * PAGE_SIZE as u64;
 
         let mut file = self.get_file_handle(table_id)?;
         let mut buffer = [0u8; PAGE_SIZE];
@@ -41,7 +66,8 @@ impl DiskManager {
             if e.kind() == std::io::ErrorKind::UnexpectedEof {
                 DatabaseError::Storage(format!(
                     "Read past EOF: page {} in table {}",
-                    page_id.0, table_id
+                    page_id.page_idx(),
+                    table_id
                 ))
             } else {
                 DatabaseError::Io(e.to_string())
@@ -51,13 +77,14 @@ impl DiskManager {
         Ok(buffer)
     }
 
+    /// Writes a page to disk using in-place overwrite followed by fsync.
     pub fn write_page(
         &mut self,
-        table_id: u32,
         page_id: PageId,
         data: &[u8; PAGE_SIZE],
     ) -> Result<(), DatabaseError> {
-        let offset = page_id.0 as u64 * PAGE_SIZE as u64;
+        let table_id = page_id.table_id();
+        let offset = page_id.page_idx() as u64 * PAGE_SIZE as u64;
 
         let mut file = self.get_file_handle(table_id)?;
         file.seek(SeekFrom::Start(offset))?;
@@ -67,8 +94,23 @@ impl DiskManager {
         Ok(())
     }
 
+    /// Performs an atomic write by writing to a temporary file and renaming it.
+    ///
+    /// This pattern ensures that a crash during the write operation does not
+    /// leave the original file in a corrupted or "torn" state.
+    pub fn safe_write_page(
+        &mut self,
+        page_id: PageId,
+        data: &[u8; PAGE_SIZE],
+    ) -> Result<(), DatabaseError> {
+        let table_id = page_id.table_id();
+        let offset = page_id.page_idx() as u64 * PAGE_SIZE as u64;
+        self.atomic_write(table_id, offset, data)
+    }
+
+    /// Appends a new 8KB page to the end of the specified table file.
     pub fn allocate_page(&mut self, table_id: u32) -> Result<PageId, DatabaseError> {
-        let mut file = self.get_file_handle(table_id)?;
+        let file = self.get_file_handle(table_id)?;
         let file_len = file.metadata()?.len();
 
         if !file_len.is_multiple_of(PAGE_SIZE as u64) {
@@ -79,14 +121,51 @@ impl DiskManager {
         }
 
         let page_idx = (file_len / PAGE_SIZE as u64) as u32;
-        let page_id = PageId(page_idx);
+        let page_id = PageId::new(table_id, page_idx);
 
         let empty_page = [0u8; PAGE_SIZE];
-        file.seek(SeekFrom::End(0))?;
-        file.write_all(&empty_page)?;
-        file.sync_all()?;
+        self.atomic_write(table_id, file_len, &empty_page)?;
 
         Ok(page_id)
+    }
+
+    /// Internal atomic write mechanism implementing Temp-Flush-Rename.
+    fn atomic_write(
+        &mut self,
+        table_id: u32,
+        offset: u64,
+        data: &[u8],
+    ) -> Result<(), DatabaseError> {
+        let path = self.resolve_physical_location_path(table_id);
+        let temp_path = path.with_extension("tmp");
+
+        if path.exists() {
+            fs::copy(&path, &temp_path)?;
+        }
+
+        {
+            let mut temp_file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&temp_path)?;
+
+            temp_file.seek(SeekFrom::Start(offset))?;
+            temp_file.write_all(data)?;
+            temp_file.sync_all()?;
+        }
+
+        fs::rename(&temp_path, &path)?;
+
+        if let Some(parent) = path.parent() {
+            let dir = File::open(parent)?;
+            dir.sync_all()?;
+        }
+
+        // Drop the cached handle as the filesystem inode has changed.
+        self.opened_files.remove(&table_id);
+
+        Ok(())
     }
 
     fn resolve_physical_location_path(&self, table_id: u32) -> PathBuf {
@@ -100,7 +179,7 @@ impl DiskManager {
                 .read(true)
                 .write(true)
                 .create(true)
-                .truncate(true)
+                .truncate(false)
                 .open(path)?;
             self.opened_files.insert(table_id, file);
         }

--- a/crates/wackdb_storage/src/disk_manager.rs
+++ b/crates/wackdb_storage/src/disk_manager.rs
@@ -8,18 +8,14 @@ use wackdb_common::constants::PAGE_SIZE;
 use wackdb_common::errors::DatabaseError;
 use wackdb_common::types::PageId;
 
-/// DiskManager manages the physical persistence of fixed-size 8KB pages.
-///
-/// It provides basic I/O operations and guarantees atomicity during page updates
-/// by employing a temporary file swap (Shadow Paging) strategy combined with
-/// explicit filesystem synchronization.
+/// DiskManager manages the physical persistence of fixed-size pages
 pub struct DiskManager {
     data_dir: PathBuf,
     opened_files: HashMap<u32, File>,
 }
 
 impl DiskManager {
-    /// Initializes the DiskManager and ensures the data directory exists.
+    /// Initializes the DiskManager and ensures the data directory exists
     pub fn new(config: &Config) -> Result<Self, DatabaseError> {
         let data_dir = PathBuf::from(&config.data_dir);
         if !data_dir.exists() {
@@ -32,7 +28,7 @@ impl DiskManager {
         })
     }
 
-    /// Creates a new database file for the specified table ID.
+    /// Creates a new database file for the specified table ID
     pub fn create_file(&mut self, table_id: u32) -> Result<(), DatabaseError> {
         let path = self.resolve_physical_location_path(table_id);
         if path.exists() {
@@ -53,7 +49,7 @@ impl DiskManager {
         Ok(())
     }
 
-    /// Reads an 8KB page from disk.
+    /// Reads a page from disk
     pub fn read_page(&mut self, page_id: PageId) -> Result<[u8; PAGE_SIZE], DatabaseError> {
         let table_id = page_id.table_id();
         let offset = page_id.page_idx() as u64 * PAGE_SIZE as u64;
@@ -77,7 +73,7 @@ impl DiskManager {
         Ok(buffer)
     }
 
-    /// Writes a page to disk using in-place overwrite followed by fsync.
+    /// Writes a page to disk using in-place overwrite followed by fsync
     pub fn write_page(
         &mut self,
         page_id: PageId,
@@ -94,10 +90,7 @@ impl DiskManager {
         Ok(())
     }
 
-    /// Performs an atomic write by writing to a temporary file and renaming it.
-    ///
-    /// This pattern ensures that a crash during the write operation does not
-    /// leave the original file in a corrupted or "torn" state.
+    /// Performs an atomic write by writing to a temporary file and renaming it
     pub fn safe_write_page(
         &mut self,
         page_id: PageId,
@@ -108,7 +101,7 @@ impl DiskManager {
         self.atomic_write(table_id, offset, data)
     }
 
-    /// Appends a new 8KB page to the end of the specified table file.
+    /// Appends a new page to the end of the specified table file
     pub fn allocate_page(&mut self, table_id: u32) -> Result<PageId, DatabaseError> {
         let file = self.get_file_handle(table_id)?;
         let file_len = file.metadata()?.len();
@@ -129,7 +122,7 @@ impl DiskManager {
         Ok(page_id)
     }
 
-    /// Internal atomic write mechanism implementing Temp-Flush-Rename.
+    /// Internal atomic write mechanism implementing Temp-Flush-Rename
     fn atomic_write(
         &mut self,
         table_id: u32,
@@ -162,7 +155,7 @@ impl DiskManager {
             dir.sync_all()?;
         }
 
-        // Drop the cached handle as the filesystem inode has changed.
+        // Drop the cached handle as the filesystem inode has changed
         self.opened_files.remove(&table_id);
 
         Ok(())

--- a/crates/wackdb_storage/tests/disk_manager_test.rs
+++ b/crates/wackdb_storage/tests/disk_manager_test.rs
@@ -1,7 +1,6 @@
 use tempfile::tempdir;
 use wackdb_common::config::Config;
 use wackdb_common::constants::PAGE_SIZE;
-use wackdb_common::types::PageId;
 use wackdb_storage::DiskManager;
 
 #[test]
@@ -16,22 +15,46 @@ fn test_disk_manager_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
     let table_id = 1;
 
     let page_id = dm.allocate_page(table_id)?;
-    assert_eq!(page_id, PageId(0));
+    assert_eq!(page_id.page_idx(), 0);
+    assert_eq!(page_id.table_id(), table_id);
 
     let mut data = [0u8; PAGE_SIZE];
     data[0] = 42;
     data[PAGE_SIZE - 1] = 24;
-    dm.write_page(table_id, page_id, &data)?;
+    dm.write_page(page_id, &data)?;
 
-    let read_data = dm.read_page(table_id, page_id)?;
+    let read_data = dm.read_page(page_id)?;
     assert_eq!(data, read_data);
 
     let page_id2 = dm.allocate_page(table_id)?;
-    assert_eq!(page_id2, PageId(1));
+    assert_eq!(page_id2.page_idx(), 1);
 
     let table2_id = 2;
     let t2_page0 = dm.allocate_page(table2_id)?;
-    assert_eq!(t2_page0, PageId(0));
+    assert_eq!(t2_page0.page_idx(), 0);
+    assert_eq!(t2_page0.table_id(), table2_id);
+
+    Ok(())
+}
+
+#[test]
+fn test_disk_manager_safe_write() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    let config = Config {
+        data_dir: dir.path().to_str().unwrap().to_string(),
+        ..Config::default()
+    };
+
+    let mut dm = DiskManager::new(&config)?;
+    let table_id = 1;
+    let page_id = dm.allocate_page(table_id)?;
+
+    let mut data = [0u8; PAGE_SIZE];
+    data[0] = 100;
+    dm.safe_write_page(page_id, &data)?;
+
+    let read_data = dm.read_page(page_id)?;
+    assert_eq!(data, read_data);
 
     Ok(())
 }


### PR DESCRIPTION
Closes #10 
This PR adds atomic writing  to `DiskManager` struct
- [X] Simulated interruption during writing does not affect the original file.
- [X] Upon completion, the final file is identical to the expected one.
- [X] Directory synchronization to ensure OS metadata.
